### PR TITLE
Event & theme fixes

### DIFF
--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -515,8 +515,8 @@ class PdfViewerElement extends
         this.__document = pdfjsLib.getDocument(src);
         return this.__document.promise.then((pdfDocument) => {
             // Document loaded, specifying document for the viewer.
-            this.__viewer.setDocument(pdfDocument);
             this.__thumbnailViewer.setDocument(pdfDocument);
+            this.__viewer.setDocument(pdfDocument);
             this.__linkService.setDocument(pdfDocument);
 
             this.$.toolbar.classList.add('ready');

--- a/theme/material/vcf-pdf-viewer.js
+++ b/theme/material/vcf-pdf-viewer.js
@@ -1,2 +1,2 @@
-import './theme/material/vcf-pdf-viewer.js';
-export * from './src/vcf-pdf-viewer.js';
+import '../../src/vcf-pdf-viewer.js';
+import './vcf-pdf-viewer-styles.js';


### PR DESCRIPTION
- Fix setting document on thumbnails viewer so thumbnails can be loaded when setting that the thumbnail viewer is open at start. This will allow to add an onClick function on each thumbnail and trigger the thumbnail-clicked event that was missing.

Close #2 

- Fix imports on material theme file.