### PR TITLE
Add properties to set labels to auto and page fit zoom options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-pdf-viewer",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Polymer element providing pdf viewer",
   "main": "vcf-pdf-viewer.js",
   "repository": {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -252,8 +252,8 @@ class PdfViewerElement extends
                 <vaadin-select id="zoom" part="toolbar-zoom" value="{{zoom}}">
                 <template>
                     <vaadin-list-box>
-                        <vaadin-item value='auto'>Automatic zoom</vaadin-item>
-                        <vaadin-item value='page-fit'>Page fit</vaadin-item>
+                        <vaadin-item value='auto'>{{autoZoomOptionLabel}}</vaadin-item>
+                        <vaadin-item value='page-fit'>{{fitZoomOptionLabel}}</vaadin-item>
                         <vaadin-item value='0.5'>50%</vaadin-item>
                         <vaadin-item value='0.75'>75%</vaadin-item>
                         <vaadin-item value='1.0'>100%</vaadin-item>
@@ -386,6 +386,22 @@ class PdfViewerElement extends
             toolbarOnlyFilename: {
                 type: Boolean,
                 value: false
+            },
+
+            /**
+             * Property to define auto zoom label
+             */
+             autoZoomOptionLabel: {
+                type: String,
+                value: "Automatic zoom"
+            },
+
+            /**
+             * Property to define page fit zoom label
+             */
+            fitZoomOptionLabel: {
+                type: String,
+                value: "Page fit"
             },
         };
     }

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -289,7 +289,7 @@ class PdfViewerElement extends
     }
 
     static get version() {
-        return '1.0.0';
+        return '1.1.0';
     }
 
     static get properties() {


### PR DESCRIPTION
Provide new properties for auto & fit page zoom options labels, so is possible to customize those values.