### PR TITLE
Update fallback for lumo variable with recomended value

### DIFF
--- a/theme/lumo/vcf-pdf-viewer-styles.js
+++ b/theme/lumo/vcf-pdf-viewer-styles.js
@@ -16,7 +16,7 @@ registerStyles(
         :host {
         background-color: var(--lumo-base-color);
         border: 1px solid var(--lumo-contrast-10pct);
-        border-radius: var(--lumo-border-radius, var(--lumo-border-radius-s));
+        border-radius: var(--lumo-border-radius, var(--lumo-border-radius-m));
         font-family: var(--lumo-font-family);
         position: relative;
       }
@@ -72,7 +72,7 @@ registerStyles(
 
       [part~="toolbar-button"] {
         height: var(--lumo-size-m);
-        border-radius: var(--lumo-border-radius, var(--lumo-border-radius-s));
+        border-radius: var(--lumo-border-radius, var(--lumo-border-radius-m));
         color: var(--lumo-contrast-80pct);
         transition: background-color 100ms, color 100ms;
         margin: var(--lumo-space-xs);


### PR DESCRIPTION
This fix is related to https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/33. It was pointed out that the [recommended value](https://vaadin.com/docs/latest/styling/lumo/lumo-style-properties/shape) for replacement is --lumo-border-radius-m.