### PR TITLE
fix: add missing z-index property on zoom select styling

### DIFF
--- a/theme/lumo/vcf-pdf-viewer-styles.js
+++ b/theme/lumo/vcf-pdf-viewer-styles.js
@@ -167,6 +167,7 @@ registerStyles(
         background-color: white;
         box-shadow: var(--lumo-box-shadow-m);
         padding: var(--lumo-space-xs);
+        z-index: 99;
       }
      `,
     { moduleId: 'lumo-vcf-pdf-viewer' }

--- a/theme/material/vcf-pdf-viewer-styles.js
+++ b/theme/material/vcf-pdf-viewer-styles.js
@@ -116,6 +116,7 @@ registerStyles(
         background-color: white;
         border: 1px solid rgba(0, 0, 0, 0.12);
         padding: 0 4px;
+        z-index: 99;
       }
       `,
   { moduleId: 'material-vcf-pdf-viewer' }


### PR DESCRIPTION
Reported in https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/42