### PR TITLE
Move toolbar components to light dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-pdf-viewer",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Polymer element providing pdf viewer",
   "main": "vcf-pdf-viewer.js",
   "repository": {
@@ -28,6 +28,7 @@
     "@vaadin/button": "^24.1.1",
     "@vaadin/component-base": "^24.1.1",
     "@vaadin/icon": "^24.1.1",
+    "@vaadin/icons": "^24.1.1",
     "@vaadin/item": "^24.1.1",
     "@vaadin/list-box": "^24.1.1",
     "@vaadin/select": "^24.1.1",

--- a/theme/lumo/vcf-pdf-viewer-styles.js
+++ b/theme/lumo/vcf-pdf-viewer-styles.js
@@ -13,7 +13,7 @@ import '@vaadin/item/theme/lumo/vaadin-item-styles.js';
 registerStyles(
     'vcf-pdf-viewer',
     css`
-        :host {
+      :host {
         background-color: var(--lumo-base-color);
         border: 1px solid var(--lumo-contrast-10pct);
         border-radius: var(--lumo-border-radius, var(--lumo-border-radius-m));
@@ -47,7 +47,7 @@ registerStyles(
         justify-content: flex-end;
       }
 
-      [part~="toolbar-current-page"] {
+      ::slotted(.toolbar-current-page) {
         width: 3.25em;
       }
 
@@ -70,7 +70,7 @@ registerStyles(
         text-overflow: ellipsis;
       }
 
-      [part~="toolbar-button"] {
+      ::slotted(.toolbar-button){
         height: var(--lumo-size-m);
         border-radius: var(--lumo-border-radius, var(--lumo-border-radius-m));
         color: var(--lumo-contrast-80pct);
@@ -78,47 +78,31 @@ registerStyles(
         margin: var(--lumo-space-xs);
         background: transparent;
         border: none;
-        padding-top: 0.2em;
+        padding-top: 0.3em;
       }
 
-      [part~="toolbar-button"][disabled] {
+      ::slotted(.toolbar-button[disabled]) {
         color: var(--lumo-contrast-40pct);
       }
 
-      [part~="toolbar-button"]:hover {
+      ::slotted(.toolbar-button:hover) {
         background-color: var(--lumo-contrast-5pct);
         color: var(--lumo-contrast-80pct);
       }
 
-      [part~="toolbar-button"][disabled]:hover {
+      ::slotted(.toolbar-button[disabled]:hover) {
         background-color: transparent;
         color: var(--lumo-contrast-40pct);
       }
 
-      [part~="toolbar-button"]:focus {
+      ::slotted(.toolbar-button:focus) {
         outline: none;
         box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
       }
 
-      [part~="toolbar-button"] {
+      ::slotted(.toolbar-button) {
         font-family: 'lumo-icons';
         font-size: var(--lumo-icon-size-m);
-      }
-
-      [part~="previous-page-button-icon"]::before {
-        content: var(--lumo-icons-angle-up);
-      }
-
-      [part~="next-page-button-icon"]::before {
-        content: var(--lumo-icons-angle-down);
-      }
-
-      [part~="toggle-button-icon"]::before {
-        content: var(--lumo-icons-chevron-right);
-      }
-
-      #outerContainer.sidebarOpen [part~="toggle-button-icon"]::before {
-        content: var(--lumo-icons-chevron-left);
       }
 
       .page {
@@ -159,7 +143,7 @@ registerStyles(
         flex: none;
       }
 
-      [part~="toolbar"].small-size [part~="toolbar-zoom"] {
+      [part~="toolbar"].small-size ::slotted(.toolbar-zoom) {
         position: absolute;
         bottom: var(--lumo-space-s);
         left: 50%;

--- a/theme/lumo/vcf-pdf-viewer-toolbar-icons-styles.js
+++ b/theme/lumo/vcf-pdf-viewer-toolbar-icons-styles.js
@@ -1,0 +1,29 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+import '@vaadin/icon/theme/lumo/vaadin-icon-styles.js';
+
+import '@vaadin/vaadin-lumo-styles/font-icons.js';
+
+registerStyles(
+    'vaadin-icon',
+    css`
+      :host(.previous-page-button-icon)::before {
+        content: var(--pdf-viewer-previous-page-button-icon, var(--lumo-icons-angle-up));
+      }
+
+      :host(.next-page-button-icon)::before {
+        content: var(--pdf-viewer-next-page-button-icon, var(--lumo-icons-angle-down));
+      }
+
+      :host(.toggle-button-icon)::before {
+        content: var(--pdf-viewer-toggle-button-icon, var(--lumo-icons-chevron-right));
+      }
+   
+      :host(.sidebarOpen.toggle-button-icon)::before {
+        content:var(--pdf-viewer-toggle-button-icon, var(--lumo-icons-chevron-left));
+      } 
+   
+     `,
+    { moduleId: 'lumo-vcf-pdf-viewer-toolbar-icons' }
+  );
+  

--- a/theme/lumo/vcf-pdf-viewer.js
+++ b/theme/lumo/vcf-pdf-viewer.js
@@ -1,2 +1,3 @@
 import '../../src/vcf-pdf-viewer.js';
 import './vcf-pdf-viewer-styles.js';
+import './vcf-pdf-viewer-toolbar-icons-styles.js';


### PR DESCRIPTION
The changes in this PR are meant to expose Vaadin components in the toolbar (such as vaadin-button, vaadin-text-field, and vaadin-select) to the light DOM. This adjustment enhances accessibility & styling.

This is considered a breaking change so version of the component was updated to 3.0.0.