### PR TITLE
 Force rendering to avoid blurry display on zoom update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-pdf-viewer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Polymer element providing pdf viewer",
   "main": "vcf-pdf-viewer.js",
   "repository": {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -695,6 +695,7 @@ class PdfViewerElement extends
         // webcomponents/shadow dom messing with
         // TODO: Fix the issue so that we get rid of the error in log
         this.__viewer.currentScaleValue = value;
+        this.__viewer.forceRendering();
     }
 
     __pageChange(event) {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -307,7 +307,7 @@ class PdfViewerElement extends
     }
 
     static get version() {
-        return '1.4.1';
+        return '1.4.2';
     }
 
     static get properties() {


### PR DESCRIPTION
This fixes https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/57 for Vaadin 23 version.