### PR TITLE
Force rendering to avoid blurry display on zoom update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-pdf-viewer",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Polymer element providing pdf viewer",
   "main": "vcf-pdf-viewer.js",
   "repository": {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -287,7 +287,7 @@ class PdfViewerElement extends
     }
 
     static get version() {
-        return '3.0.1';
+        return '3.0.2';
     }
 
     static get properties() {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -819,6 +819,7 @@ class PdfViewerElement extends
         // webcomponents/shadow dom messing with
         // TODO: Fix the issue so that we get rid of the error in log
         this.__viewer.currentScaleValue = value;
+        this.__viewer.forceRendering();
     }
 
     __pageChange(event) {


### PR DESCRIPTION
Includes Cherry pick of fix on https://github.com/vaadin-component-factory/vcf-pdf-viewer/pull/27

This fixes https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/57 for Vaadin 24 version.