### PR TITLE
feat: add methods to allow document rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-pdf-viewer",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Polymer element providing pdf viewer",
   "main": "vcf-pdf-viewer.js",
   "repository": {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -307,7 +307,7 @@ class PdfViewerElement extends
     }
 
     static get version() {
-        return '1.4.2';
+        return '1.5.0';
     }
 
     static get properties() {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -789,6 +789,24 @@ class PdfViewerElement extends
             this.__thumbnailViewer.scrollThumbnailIntoView(this.currentPage);
         }
     }
+
+    /**
+     * Rotates document clockwise.
+     */
+    rotateCw() {
+        let delta = 90;
+        this.__viewer.pagesRotation += delta;
+        this.__viewer.forceRendering();
+    }
+
+    /**
+     * Rotates document counterclockwise.
+     */
+    rotateCcw() {
+        let delta = -90;
+        this.__viewer.pagesRotation += delta;
+        this.__viewer.forceRendering();
+    }
 }
 
 customElements.define(PdfViewerElement.is, PdfViewerElement);


### PR DESCRIPTION
This PR adds new methods to allow to rotate document clockwise and counterclockwise. The rotation feature was requested via Support Request. This is part of https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/66.

Version updated to 1.5.0.
