### PR TITLE
feat: add methods to allow document rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-pdf-viewer",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Polymer element providing pdf viewer",
   "main": "vcf-pdf-viewer.js",
   "repository": {

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -914,6 +914,24 @@ class PdfViewerElement extends
             this.__thumbnailViewer.scrollThumbnailIntoView(this.currentPage);
         }
     }
+
+    /**
+     * Rotates document clockwise.
+     */
+    rotateCw() {
+        let delta = 90;
+        this.__viewer.pagesRotation += delta;
+        this.__viewer.forceRendering();
+    }
+
+    /**
+     * Rotates document counterclockwise.
+     */
+    rotateCcw() {
+        let delta = -90;
+        this.__viewer.pagesRotation += delta;
+        this.__viewer.forceRendering();
+    }
 }
 
 customElements.define(PdfViewerElement.is, PdfViewerElement);

--- a/src/vcf-pdf-viewer.js
+++ b/src/vcf-pdf-viewer.js
@@ -287,7 +287,7 @@ class PdfViewerElement extends
     }
 
     static get version() {
-        return '3.0.2';
+        return '3.1.0';
     }
 
     static get properties() {


### PR DESCRIPTION
Cherry pick of https://github.com/vaadin-component-factory/vcf-pdf-viewer/pull/29/commits/533686cec63ad9337a6b9a2fbc43a1ea270315ce. It adds new methods to allow to rotate document clockwise and counterclockwise. This is part of https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/66.

Version updated to 3.1.0.